### PR TITLE
feat: added the new options for users.

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -5,17 +5,30 @@ namespace App\Http\Controllers\Auth;
 use App\Http\Controllers\Controller;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Hash;
+use Spatie\Permission\Models\Role;
 
 class RegisterController extends Controller
 {
     protected function create(array $data)
     {
+        $profilePhotoPath = null;
+        if (isset($data['profile_photo']) && $data['profile_photo'] instanceof UploadedFile) {
+            $profilePhotoPath = $data['profile_photo']->store('profile-photos', 'public');
+        }
+
         $user = User::create([
             'name' => $data['name'],
             'email' => $data['email'],
+            'role' => $data['role'],
             'password' => Hash::make($data['password']),
+            'profile_photo_path' => $profilePhotoPath,
         ]);
+
+        if (!Role::where('name', $data['role'])->exists()) {
+            Role::create(['name' => $data['role']]);
+        }
 
         // Assign default role to the user
         $user->assignRole('cashier');

--- a/app/Http/Middleware/RoleMiddleware.php
+++ b/app/Http/Middleware/RoleMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+class RoleMiddleware
+{
+    public function handle(Request $request, Closure $next, $role)
+    {
+        if (!Auth::check() || !Auth::user()->hasRole($role)) {
+            abort(403, 'Unauthorized');
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'role',
+        'profile_photo_path',
     ];
 
     /**

--- a/database/migrations/2025_02_21_072237_add_role_to_users_table.php
+++ b/database/migrations/2025_02_21_072237_add_role_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->enum('role', ['admin', 'cashier', 'manager'])->default('cashier');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('role');
+        });
+    }
+};

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -9,6 +9,18 @@
         <form method="POST" action="{{ route('register') }}">
             @csrf
 
+            <div class="mt-4">
+                <x-label for="profile_photo" value="{{ __('Profile Photo') }}" />
+
+                <div class="mb-3">
+                    <img id="profile-photo-preview" class="w-32 h-32 rounded-full border border-gray-300 hidden" />
+                </div>
+
+                <input id="profile_photo"
+                       class="block mt-1 w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm"
+                       type="file" name="profile_photo" accept="image/*" required onchange="previewImage(event)">
+            </div>
+
             <div>
                 <x-label for="name" value="{{ __('Name') }}" />
                 <x-input id="name" class="block mt-1 w-full" type="text" name="name" :value="old('name')" required autofocus autocomplete="name" />
@@ -17,6 +29,16 @@
             <div class="mt-4">
                 <x-label for="email" value="{{ __('Email') }}" />
                 <x-input id="email" class="block mt-1 w-full" type="email" name="email" :value="old('email')" required autocomplete="username" />
+            </div>
+
+            <div class="mt-4">
+                <x-label for="role" value="{{ __('Role') }}" />
+                <select id="role" name="role" class="block mt-1 w-full border-gray-300 focus:border-indigo-500 focus:ring-indigo-500 rounded-md shadow-sm" required>
+                    <option value="" disabled selected>Select a role</option>
+                    <option value="admin">Admin</option>
+                    <option value="cashier">Cashier</option>
+                    <option value="manager">Manager</option>
+                </select>
             </div>
 
             <div class="mt-4">
@@ -56,5 +78,21 @@
                 </x-button>
             </div>
         </form>
+
+        <script>
+            function previewImage(event) {
+                const input = event.target;
+                const preview = document.getElementById('profile-photo-preview');
+
+                if (input.files && input.files[0]) {
+                    const reader = new FileReader();
+                    reader.onload = function(e) {
+                        preview.src = e.target.result;
+                        preview.classList.remove('hidden');
+                    };
+                    reader.readAsDataURL(input.files[0]);
+                }
+            }
+        </script>
     </x-authentication-card>
 </x-guest-layout>

--- a/resources/views/navigation-menu.blade.php
+++ b/resources/views/navigation-menu.blade.php
@@ -77,7 +77,7 @@
                         <x-slot name="trigger">
                             @if (Laravel\Jetstream\Jetstream::managesProfilePhotos())
                                 <button class="flex text-sm border-2 border-transparent rounded-full focus:outline-none focus:border-gray-300 transition">
-                                    <img class="size-8 rounded-full object-cover" src="{{ Auth::user()->profile_photo_url }}" alt="{{ Auth::user()->name }}" />
+                                    <img class="h-10 w-10 rounded-full" src="{{ Auth::user()->profile_photo_path ? asset(Auth::user()->profile_photo_path) : asset('default-avatar.png') }}" alt="{{ Auth::user()->name }}">
                                 </button>
                             @else
                                 <span class="inline-flex rounded-md">

--- a/resources/views/profile/show.blade.php
+++ b/resources/views/profile/show.blade.php
@@ -7,6 +7,11 @@
 
     <div>
         <div class="max-w-7xl mx-auto py-10 sm:px-6 lg:px-8">
+            <div class="bg-white shadow p-6 rounded-lg mb-6">
+                <h3 class="text-lg font-semibold mb-2">User Role</h3>
+                <p class="text-gray-600">Role: <span class="font-bold">{{ auth()->user()->role }}</span></p>
+            </div>
+            
             @if (Laravel\Fortify\Features::canUpdateProfileInformation())
                 @livewire('profile.update-profile-information-form')
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,10 +11,25 @@ Route::middleware([
     Route::get('/dashboard', function () {
         return view('dashboard');
     })->name('dashboard');
-});
 
-// Route::get('/dashboard', function () {
-//     return view('dashboard');
-// })->middleware(['auth']);
+    // Role-based dashboard routes
+    Route::middleware(['role:admin'])->group(function () {
+        Route::get('/admin-dashboard', function () {
+            return view('admin.dashboard');
+        })->name('admin.dashboard');
+    });
+
+    Route::middleware(['role:cashier'])->group(function () {
+        Route::get('/cashier-dashboard', function () {
+            return view('cashier.dashboard');
+        })->name('cashier.dashboard');
+    });
+
+    Route::middleware(['role:manager'])->group(function () {
+        Route::get('/manager-dashboard', function () {
+            return view('manager.dashboard');
+        })->name('manager.dashboard');
+    });
+});
 
 Route::resource('products', ProductController::class);


### PR DESCRIPTION
- The fortify "CreateNewUser.php" has been updated. Two new options for selecting a role and uploading a profile photo have been added with validations. And added the option for uploading photos in save to local storage. Remove the line "'terms' => Jetstream::hasTermsAndPrivacyPolicyFeature() ? ['accepted', 'required'] : '',"
- The controller "RegisterController.php" has been updated. Two new options for selecting a role and uploading a profile photo have been added with validations. And added the option for uploading photos in save to local storage.
- Added a middleware named "RoleMiddleware" for user permissions according to the role.
- Added a new column to users migration for "role". And set the data type 'enum' for select 'admin', 'cashier', and 'manager'. Set the default user role to "cashier".
- In the User model, added the two column names "role" and "profile_photo_path".
- In the 'auth/register.blade.php', add the two options for profile photo upload and select a user role. After the upload, the profile photo preview option for this, and wrote a script for the uploaded image preview.
- In the 'navigation-menu.blade.php', add the user's profile photo preview.
- In the 'show.blade.php', added the user role display.
- Added the routes according to the dashboard depending on the role "admin", "cashier", and "manager".
- Wrote the test case for creating a new user.